### PR TITLE
Include ARC header information in output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.idea
+*.iml
+target
+tags
+out*

--- a/nanite-hadoop/src/main/java/uk/bl/wap/hadoop/profiler/FormatProfiler.java
+++ b/nanite-hadoop/src/main/java/uk/bl/wap/hadoop/profiler/FormatProfiler.java
@@ -76,7 +76,7 @@ public class FormatProfiler extends Configured implements Tool {
 		
 		// search our classpath first- otherwise we get dependency problems
 		conf.setUserClassesTakesPrecedence(true);
-		
+
 		// Override the task timeout to cope with behaviour when processing malformed archive files
 		// Value set in MS.  Default value is 600,000ms (i.e. 10 mins)
 		// Set this to 30 minutes

--- a/nanite-hadoop/src/main/resources/FormatProfiler.properties
+++ b/nanite-hadoop/src/main/resources/FormatProfiler.properties
@@ -16,6 +16,8 @@ USE_LIBMAGIC=false
 # Whether to include the year of harvest (if not, will set a default year e.g. 2013 for all records)
 INCLUDE_WAYBACKYEAR=false
 # Whether to generate a c3po compatible zip per input arc (Tika parser required)
-GENERATE_C3PO_ZIP=true;
+GENERATE_C3PO_ZIP=true
 # Whether or not to generate a sequencefile per input arc containing serialized Tika parser Metadata objects
-GENERATE_SEQUENCEFILE=true;
+GENERATE_SEQUENCEFILE=true
+# Whether to include the ARC record headers in the output
+INCLUDE_ARC_HEADERS=true


### PR DESCRIPTION
I've added code that enables the inclusion of the ARC headers fields per record in the zip/sequence files.

I've added a String.replace("\n"," ") on key values. The output format is line based and "\n" in values breaks this format.

I've changed a log.info to log.trace in FormatProfileMapper.java:696
