### PR TITLE
Nanite can fill /tmp with repeated invocations

### DIFF
--- a/nanite-core/src/main/java/uk/bl/wa/nanite/droid/DroidDetector.java
+++ b/nanite-core/src/main/java/uk/bl/wa/nanite/droid/DroidDetector.java
@@ -187,6 +187,10 @@ public class DroidDetector implements Detector {
 
 		// And initialise:
 		init(fileSignaturesFile, containerSignaturesFile);
+		
+		//dont fill up tmp space with signature files
+		fileSignaturesFile.delete();
+		containerSignaturesFile.delete();
 	}
 
 	/**


### PR DESCRIPTION
These temporary files are unneeded once Nanite is up-and-running. They should be deleted to prevent filling the temporary directory.