### PR TITLE
Fix memory leak 

### DIFF
--- a/nanite-core/src/main/java/uk/gov/nationalarchives/droid/internal/api/DroidAPIExtended.java
+++ b/nanite-core/src/main/java/uk/gov/nationalarchives/droid/internal/api/DroidAPIExtended.java
@@ -187,12 +187,10 @@ public final class DroidAPIExtended {
         id.setParentId(ID_GENERATOR.getAndIncrement());
         id.setNodeId(ID_GENERATOR.getAndIncrement());
 
-        final InputStreamIdentificationRequest request = new InputStreamIdentificationRequest(metaData, id);
-        try {
+
+        try (InputStreamIdentificationRequest request = new InputStreamIdentificationRequest(metaData, id)){
         	request.open(input);
         	return submit(request);
-        } finally {
-            request.removeTempDir();
         }
     }
     


### PR DESCRIPTION
1) Made use of the try-with-resource to close the request automatically. 
2) The close method seem to remove the temp directory anyways, so the call to remove temp directory (`request.removeTempDir();`) in finally block became redundant, hence removed it.